### PR TITLE
Add Black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,16 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.4
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
-  
+
   - repo: local
     hooks:
       - id: pytest


### PR DESCRIPTION
## Summary
- add Black hook to `.pre-commit-config.yaml`
- keep Ruff and pytest hooks
- run `pre-commit install` so contributors pick up new formatting check

## Testing
- `pre-commit install`

------
https://chatgpt.com/codex/tasks/task_e_68898ab3655c8329b88b71167cbc1390