### PR TITLE
Add dynamic nutrient adjustment rules

### DIFF
--- a/app/rules.py
+++ b/app/rules.py
@@ -6,37 +6,44 @@ import json
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional
 
 from .memory.db import Database
 from .memory.kpis import KPICalculator
 
+
 class RulesEngine:
     """Implements intelligent rule-based control with stable-unless-better philosophy"""
-    
+
     def __init__(self, config: Dict[str, Any], db: Database = None):
         self.config = config
         self.db = db or Database()
         self.kpi_calc = KPICalculator(self.db)
         self.logger = logging.getLogger(__name__)
-        
+
         # Load safety limits
         self.safety_limits = self._load_safety_limits()
-        
+
+        # Track recent config changes for rollback logic
+        self._last_config_change_time: Optional[datetime] = None
+        self._previous_kpis: Optional[Dict[str, Any]] = None
+        self._last_ph_target_change: Optional[datetime] = None
+        self._last_ec_target_change: Optional[datetime] = None
+
         # Rule thresholds
         self.thresholds = {
-            'ph_in_spec_threshold': 0.9,          # 90% readings in spec
-            'ec_in_spec_threshold': 0.9,          # 90% readings in spec
-            'health_score_threshold': 0.8,        # 80% health score
-            'stability_threshold': 0.95,          # 95% in-spec for freeze
-            'dosing_variance_threshold': 0.2,     # 20% increase over baseline
-            'ph_adjustment_limit': 0.1,           # Max pH change per adjustment
-            'ec_adjustment_limit': 0.1,           # Max EC change per adjustment
-            'reservoir_change_days': {'GREENS': 14, 'FRUITS': 7},
-            'freeze_period_days': 14,             # Freeze successful config for 14 days
-            'rollback_check_hours': 48            # Check for degradation within 48h
+            "ph_in_spec_threshold": 0.9,  # 90% readings in spec
+            "ec_in_spec_threshold": 0.9,  # 90% readings in spec
+            "health_score_threshold": 0.8,  # 80% health score
+            "stability_threshold": 0.95,  # 95% in-spec for freeze
+            "dosing_variance_threshold": 0.2,  # 20% increase over baseline
+            "ph_adjustment_limit": 0.1,  # Max pH change per adjustment
+            "ec_adjustment_limit": 0.1,  # Max EC change per adjustment
+            "reservoir_change_days": {"GREENS": 14, "FRUITS": 7},
+            "freeze_period_days": 14,  # Freeze successful config for 14 days
+            "rollback_check_hours": 48,  # Check for degradation within 48h
         }
-    
+
     def _load_safety_limits(self) -> Dict[str, Any]:
         """Load safety limits from configuration"""
         try:
@@ -46,7 +53,7 @@ class RulesEngine:
                     return json.load(f)
         except Exception as e:
             self.logger.warning(f"Could not load safety limits: {e}")
-        
+
         # Default safety limits
         return {
             "ph_min_absolute": 4.0,
@@ -58,108 +65,125 @@ class RulesEngine:
             "max_daily_dose_ml": 200,
             "max_single_dose_ml": 50,
             "fan_max_speed": 100,
-            "led_max_power": 100
+            "led_max_power": 100,
         }
-    
-    async def evaluate_rules(self, sensor_data: Dict[str, Any], 
-                           current_kpis: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def evaluate_rules(
+        self, sensor_data: Dict[str, Any], current_kpis: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Evaluate all rules and return recommended actions"""
         try:
             # Get 7-day trends for decision making
             trends = await self.kpi_calc.calculate_7day_trends()
-            
+
             recommendations = {
                 "timestamp": datetime.utcnow().isoformat(),
                 "rule_evaluations": [],
                 "actions": {},
                 "freeze_status": await self._check_freeze_status(trends),
-                "rollback_required": await self._check_rollback_required(current_kpis)
+                "rollback_required": await self._check_rollback_required(current_kpis),
             }
-            
+
             # Skip adjustments if system is frozen or rollback required
             if recommendations["freeze_status"]["frozen"]:
-                recommendations["rule_evaluations"].append({
-                    "rule": "freeze_check",
-                    "result": "System frozen - excellent performance maintained",
-                    "action": "none"
-                })
+                recommendations["rule_evaluations"].append(
+                    {
+                        "rule": "freeze_check",
+                        "result": "System frozen - excellent performance maintained",
+                        "action": "none",
+                    }
+                )
                 return recommendations
-            
+
             if recommendations["rollback_required"]["required"]:
-                recommendations["actions"]["rollback"] = recommendations["rollback_required"]
+                recommendations["actions"]["rollback"] = recommendations[
+                    "rollback_required"
+                ]
                 return recommendations
-            
+
             # Evaluate pH adjustment rules
             ph_action = await self._evaluate_ph_rules(sensor_data, trends)
             if ph_action:
                 recommendations["rule_evaluations"].append(ph_action)
                 if "action" in ph_action:
                     recommendations["actions"]["ph_adjustment"] = ph_action["action"]
-            
+
             # Evaluate EC adjustment rules
             ec_action = await self._evaluate_ec_rules(sensor_data, trends, current_kpis)
             if ec_action:
                 recommendations["rule_evaluations"].append(ec_action)
                 if "action" in ec_action:
                     recommendations["actions"]["ec_adjustment"] = ec_action["action"]
-            
+
             # Evaluate environmental control rules
-            env_actions = await self._evaluate_environmental_rules(sensor_data, current_kpis)
+            env_actions = await self._evaluate_environmental_rules(
+                sensor_data, current_kpis
+            )
             if env_actions:
                 recommendations["rule_evaluations"].extend(env_actions)
                 for action in env_actions:
                     if "action" in action:
                         action_type = action.get("type", "environmental")
                         recommendations["actions"][action_type] = action["action"]
-            
+
             # Evaluate reservoir change rules
             reservoir_action = await self._evaluate_reservoir_rules(current_kpis)
             if reservoir_action:
                 recommendations["rule_evaluations"].append(reservoir_action)
                 if "action" in reservoir_action:
                     recommendations["actions"]["reservoir"] = reservoir_action["action"]
-            
+
+            # Record any configuration changes for rollback tracking
+            for evaluation in recommendations["rule_evaluations"]:
+                action = evaluation.get("action", {})
+                if isinstance(action, dict) and action.get("type") == "config_change":
+                    self._last_config_change_time = datetime.utcnow()
+                    self._previous_kpis = current_kpis.copy()
+                    if "ph_target" in action:
+                        self._last_ph_target_change = self._last_config_change_time
+                    if "ec_target" in action:
+                        self._last_ec_target_change = self._last_config_change_time
+                    break
+
             return recommendations
-            
+
         except Exception as e:
             self.logger.error(f"Rules evaluation failed: {e}")
-            return {
-                "error": str(e),
-                "timestamp": datetime.utcnow().isoformat()
-            }
-    
-    async def _evaluate_ph_rules(self, sensor_data: Dict[str, Any], 
-                               trends: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+            return {"error": str(e), "timestamp": datetime.utcnow().isoformat()}
+
+    async def _evaluate_ph_rules(
+        self, sensor_data: Dict[str, Any], trends: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Evaluate pH adjustment rules"""
         try:
-            current_ph = sensor_data.get('water', {}).get('ph')
-            ph_target = self.config.get('targets', {}).get('ph_target', 6.0)
-            ph_in_spec_7day = trends.get('ph_in_spec_7day', 100)
-            
+            current_ph = sensor_data.get("water", {}).get("ph")
+            ph_target = self.config.get("targets", {}).get("ph_target", 6.0)
+            ph_in_spec_7day = trends.get("ph_in_spec_7day", 100)
+
             if current_ph is None:
                 return None
-            
+
             # Rule: Adjust pH if 7-day in-spec < 90%
-            if ph_in_spec_7day < (self.thresholds['ph_in_spec_threshold'] * 100):
-                
+            if ph_in_spec_7day < (self.thresholds["ph_in_spec_threshold"] * 100):
                 # Calculate adjustment direction and amount
                 ph_deviation = current_ph - ph_target
-                
+
                 # Only adjust if deviation is significant (> 0.2 pH units)
                 if abs(ph_deviation) > 0.2:
-                    
                     # Limit adjustment to maximum safe amount
-                    adjustment = min(abs(ph_deviation) * 0.5, self.thresholds['ph_adjustment_limit'])
-                    
+                    adjustment = min(
+                        abs(ph_deviation) * 0.5, self.thresholds["ph_adjustment_limit"]
+                    )
+
                     if ph_deviation > 0:  # pH too high, need to lower
                         dosage_ml = self._calculate_ph_down_dosage(adjustment)
                         reason = f"pH {current_ph} > target {ph_target}, 7-day in-spec: {ph_in_spec_7day}%"
                     else:  # pH too low, need to raise
                         dosage_ml = self._calculate_ph_up_dosage(adjustment)
                         reason = f"pH {current_ph} < target {ph_target}, 7-day in-spec: {ph_in_spec_7day}%"
-                    
+
                     # Safety check
-                    if self._is_dosage_safe('ph_pump', dosage_ml):
+                    if self._is_dosage_safe("ph_pump", dosage_ml):
                         return {
                             "rule": "ph_adjustment",
                             "result": f"pH adjustment needed: {reason}",
@@ -167,44 +191,82 @@ class RulesEngine:
                                 "type": "dose",
                                 "ph_pump": {
                                     "ml": round(dosage_ml, 1),
-                                    "reason": reason
-                                }
-                            }
+                                    "reason": reason,
+                                },
+                            },
                         }
-            
+
+                # Also consider nudging pH target slightly if stability is poor
+                if (
+                    not self._last_ph_target_change
+                    or datetime.utcnow() - self._last_ph_target_change
+                    > timedelta(days=7)
+                ):
+                    trend = trends.get("ph_trend", "stable")
+                    if trend == "increasing" or current_ph > ph_target:
+                        nudge = 0.1
+                    elif trend == "decreasing" or current_ph < ph_target:
+                        nudge = -0.1
+                    else:
+                        nudge = 0.0
+
+                    if nudge != 0.0:
+                        new_target = round(ph_target + nudge, 2)
+                        new_target = max(
+                            self.config["targets"].get("ph_min", 5.5),
+                            min(new_target, self.config["targets"].get("ph_max", 6.5)),
+                        )
+                        return {
+                            "rule": "ph_target_nudge",
+                            "result": f"7-day pH in-spec {ph_in_spec_7day}% - nudging target to {new_target}",
+                            "action": {
+                                "type": "config_change",
+                                "ph_target": new_target,
+                                "reason": "pH target nudge due to instability",
+                            },
+                        }
+
             return {
                 "rule": "ph_check",
                 "result": f"pH stable: current {current_ph}, 7-day in-spec: {ph_in_spec_7day}%",
-                "action": None
+                "action": None,
             }
-            
+
         except Exception as e:
             self.logger.error(f"pH rule evaluation failed: {e}")
             return None
-    
-    async def _evaluate_ec_rules(self, sensor_data: Dict[str, Any], 
-                               trends: Dict[str, Any], 
-                               current_kpis: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    async def _evaluate_ec_rules(
+        self,
+        sensor_data: Dict[str, Any],
+        trends: Dict[str, Any],
+        current_kpis: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
         """Evaluate EC adjustment rules"""
         try:
-            current_ec = sensor_data.get('water', {}).get('ec')
-            ec_target = self.config.get('targets', {}).get('ec_target', 1.6)
-            ec_in_spec_7day = trends.get('ec_in_spec_7day', 100)
-            health_score = current_kpis.get('health_score', 1.0)
-            ml_total_7day = trends.get('ml_total_7day', 0)
-            
+            current_ec = sensor_data.get("water", {}).get("ec")
+            ec_target = self.config.get("targets", {}).get("ec_target", 1.6)
+            ec_in_spec_7day = trends.get("ec_in_spec_7day", 100)
+            health_score = current_kpis.get("health_score", 1.0)
+            ml_total_7day = trends.get("ml_total_7day", 0)
+
             if current_ec is None:
                 return None
-            
+
             # Rule 1: Raise EC if low in-spec and low health score
-            if (ec_in_spec_7day < (self.thresholds['ec_in_spec_threshold'] * 100) and 
-                health_score < self.thresholds['health_score_threshold']):
-                
+            if (
+                ec_in_spec_7day < (self.thresholds["ec_in_spec_threshold"] * 100)
+                and health_score < self.thresholds["health_score_threshold"]
+            ):
                 if current_ec < ec_target:
-                    adjustment = min(ec_target - current_ec, self.thresholds['ec_adjustment_limit'])
-                    dosage_ml = self._calculate_nutrient_dosage(adjustment, increase=True)
-                    
-                    if self._is_dosage_safe('pump_a', dosage_ml):
+                    adjustment = min(
+                        ec_target - current_ec, self.thresholds["ec_adjustment_limit"]
+                    )
+                    dosage_ml = self._calculate_nutrient_dosage(
+                        adjustment, increase=True
+                    )
+
+                    if self._is_dosage_safe("pump_a", dosage_ml):
                         return {
                             "rule": "ec_increase",
                             "result": f"EC increase needed: health {health_score}, in-spec {ec_in_spec_7day}%",
@@ -212,285 +274,346 @@ class RulesEngine:
                                 "type": "dose",
                                 "pump_a": {
                                     "ml": round(dosage_ml * 0.6, 1),  # Part A
-                                    "reason": f"Raise EC from {current_ec} toward {ec_target}"
+                                    "reason": f"Raise EC from {current_ec} toward {ec_target}",
                                 },
                                 "pump_b": {
                                     "ml": round(dosage_ml * 0.4, 1),  # Part B
-                                    "reason": f"Raise EC from {current_ec} toward {ec_target}"
-                                }
-                            }
+                                    "reason": f"Raise EC from {current_ec} toward {ec_target}",
+                                },
+                            },
                         }
-            
-            # Rule 2: Lower EC if excessive dosing detected
-            baseline_ml = self.config.get('baseline_dosing_ml_per_week', 50)
-            if ml_total_7day > baseline_ml * (1 + self.thresholds['dosing_variance_threshold']):
-                if current_ec > ec_target and ec_in_spec_7day > 95:
-                    adjustment = min(current_ec - ec_target, self.thresholds['ec_adjustment_limit'])
-                    
+
+                # Consider nudging EC target upward when stability is poor
+                if ec_target < 2.2:
                     return {
-                        "rule": "ec_decrease",
-                        "result": f"Excessive dosing detected: {ml_total_7day}ml > {baseline_ml}ml baseline",
+                        "rule": "ec_target_raise",
+                        "result": f"EC in-spec {ec_in_spec_7day}% and health {health_score} low - raise target",
                         "action": {
                             "type": "config_change",
-                            "ec_target": round(ec_target - adjustment, 2),
-                            "reason": f"Reduce EC target due to excessive dosing"
-                        }
+                            "ec_target": round(min(2.2, ec_target + 0.1), 2),
+                            "reason": "Increase EC target for poor performance",
+                        },
                     }
-            
+
+            # Rule 2: Lower EC target if dosing is high and EC generally in spec
+            baseline_ml = self.config.get("baseline_dosing_ml_per_week", 50)
+            if ec_in_spec_7day > 95 and ml_total_7day > baseline_ml * (
+                1 + self.thresholds["dosing_variance_threshold"]
+            ):
+                new_target = max(1.4, round(ec_target - 0.1, 2))
+                return {
+                    "rule": "ec_decrease",
+                    "result": f"Excessive dosing detected: {ml_total_7day}ml > {baseline_ml}ml baseline",
+                    "action": {
+                        "type": "config_change",
+                        "ec_target": new_target,
+                        "reason": "Reduce EC target due to excessive dosing",
+                    },
+                }
+
+            # Rule 3: Temporary EC reduction when high light coincides with high EC readings
+            current_lux = sensor_data.get("light", {}).get("lux", 0)
+            if current_lux > 30000:
+                recent = await self.db.get_recent_sensor_data(hours=6)
+                high_count = sum(1 for r in recent if (r.get("ec") or 0) > ec_target)
+                if high_count >= 3:
+                    temp_target = max(1.4, round(ec_target - 0.1, 2))
+                    return {
+                        "rule": "lux_ec_temp_lower",
+                        "result": f"High light {current_lux} lux with frequent high EC readings",
+                        "action": {
+                            "type": "config_change",
+                            "ec_target": temp_target,
+                            "reason": "Temporary EC reduction due to light stress",
+                        },
+                    }
+
             return {
-                "rule": "ec_check", 
-                "result": f"EC stable: current {current_ec}, target {ec_target}, 7-day in-spec: {ec_in_spec_7day}%"
+                "rule": "ec_check",
+                "result": f"EC stable: current {current_ec}, target {ec_target}, 7-day in-spec: {ec_in_spec_7day}%",
             }
-            
+
         except Exception as e:
             self.logger.error(f"EC rule evaluation failed: {e}")
             return None
-    
-    async def _evaluate_environmental_rules(self, sensor_data: Dict[str, Any],
-                                          current_kpis: Dict[str, Any]) -> List[Dict[str, Any]]:
+
+    async def _evaluate_environmental_rules(
+        self, sensor_data: Dict[str, Any], current_kpis: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """Evaluate environmental control rules"""
         actions = []
-        
+
         try:
-            air = sensor_data.get('air', {})
-            light = sensor_data.get('light', {})
-            current_temp = air.get('temperature')
-            current_humidity = air.get('humidity')
-            current_lux = light.get('lux', 0)
-            
+            air = sensor_data.get("air", {})
+            light = sensor_data.get("light", {})
+            current_temp = air.get("temperature")
+            current_humidity = air.get("humidity")
+            current_lux = light.get("lux", 0)
+
             # Temperature control
             if current_temp is not None:
-                temp_target = self.config.get('targets', {}).get('temp_target', 22)
+                temp_target = self.config.get("targets", {}).get("temp_target", 22)
                 temp_range = 2.0  # ±2°C tolerance
-                
+
                 if current_temp > temp_target + temp_range:
                     # Too hot - increase fan speed
                     fan_speed = min(80, int((current_temp - temp_target) * 20))
-                    actions.append({
-                        "rule": "temperature_cooling",
-                        "result": f"Temperature {current_temp}°C > {temp_target + temp_range}°C",
-                        "type": "fan",
-                        "action": {
-                            "fan_speed": fan_speed,
-                            "duration_minutes": 30,
-                            "reason": f"Cooling: temperature {current_temp}°C too high"
+                    actions.append(
+                        {
+                            "rule": "temperature_cooling",
+                            "result": f"Temperature {current_temp}°C > {temp_target + temp_range}°C",
+                            "type": "fan",
+                            "action": {
+                                "fan_speed": fan_speed,
+                                "duration_minutes": 30,
+                                "reason": f"Cooling: temperature {current_temp}°C too high",
+                            },
                         }
-                    })
-                
+                    )
+
                 elif current_temp < temp_target - temp_range:
                     # Too cold - reduce fan, maybe increase LED heat
-                    actions.append({
-                        "rule": "temperature_heating",
-                        "result": f"Temperature {current_temp}°C < {temp_target - temp_range}°C",
-                        "type": "environmental",
-                        "action": {
-                            "fan_speed": 10,  # Minimal fan
-                            "reason": f"Reduce cooling: temperature {current_temp}°C too low"
+                    actions.append(
+                        {
+                            "rule": "temperature_heating",
+                            "result": f"Temperature {current_temp}°C < {temp_target - temp_range}°C",
+                            "type": "environmental",
+                            "action": {
+                                "fan_speed": 10,  # Minimal fan
+                                "reason": f"Reduce cooling: temperature {current_temp}°C too low",
+                            },
                         }
-                    })
-            
+                    )
+
             # Humidity control
             if current_humidity is not None:
-                humidity_target = self.config.get('targets', {}).get('humidity_target', 60)
-                
                 if current_humidity > 80:  # High humidity risk
-                    actions.append({
-                        "rule": "humidity_control",
-                        "result": f"High humidity {current_humidity}% > 80%",
-                        "type": "fan",
-                        "action": {
-                            "fan_speed": 60,
-                            "duration_minutes": 20,
-                            "reason": f"Humidity control: {current_humidity}% too high"
+                    actions.append(
+                        {
+                            "rule": "humidity_control",
+                            "result": f"High humidity {current_humidity}% > 80%",
+                            "type": "fan",
+                            "action": {
+                                "fan_speed": 60,
+                                "duration_minutes": 20,
+                                "reason": f"Humidity control: {current_humidity}% too high",
+                            },
                         }
-                    })
-            
+                    )
+
             # Light control (basic DLI management)
             if current_lux > 30000:  # Very bright conditions
-                current_ec = sensor_data.get('water', {}).get('ec', 0)
+                current_ec = sensor_data.get("water", {}).get("ec", 0)
                 if current_ec > 2.0:  # High light + high EC = potential stress
-                    actions.append({
-                        "rule": "light_stress_prevention",
-                        "result": f"High light {current_lux} lux + high EC {current_ec} = stress risk",
-                        "type": "led",
-                        "action": {
-                            "led_power": 70,  # Reduce LED power
-                            "reason": "Prevent light stress with high EC"
+                    actions.append(
+                        {
+                            "rule": "light_stress_prevention",
+                            "result": f"High light {current_lux} lux + high EC {current_ec} = stress risk",
+                            "type": "led",
+                            "action": {
+                                "led_power": 70,  # Reduce LED power
+                                "reason": "Prevent light stress with high EC",
+                            },
                         }
-                    })
-            
+                    )
+
             return actions
-            
+
         except Exception as e:
             self.logger.error(f"Environmental rules evaluation failed: {e}")
             return []
-    
-    async def _evaluate_reservoir_rules(self, current_kpis: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    async def _evaluate_reservoir_rules(
+        self, current_kpis: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Evaluate reservoir change rules"""
         try:
-            days_since_change = current_kpis.get('days_since_reservoir_change', 0)
-            grow_phase = self.config.get('grow_phase', 'GREENS')
-            max_days = self.thresholds['reservoir_change_days'].get(grow_phase, 14)
-            
+            days_since_change = current_kpis.get("days_since_reservoir_change", 0)
+            grow_phase = self.config.get("grow_phase", "GREENS")
+            max_days = self.thresholds["reservoir_change_days"].get(grow_phase, 14)
+
             if days_since_change >= max_days:
                 return {
                     "rule": "reservoir_change_cadence",
                     "result": f"Reservoir change due: {days_since_change} days >= {max_days} days for {grow_phase}",
                     "action": {
                         "type": "reservoir_change",
-                        "reason": f"Scheduled change for {grow_phase} phase after {days_since_change} days"
-                    }
+                        "reason": f"Scheduled change for {grow_phase} phase after {days_since_change} days",
+                    },
                 }
-            
+
             return {
                 "rule": "reservoir_check",
-                "result": f"Reservoir OK: {days_since_change}/{max_days} days for {grow_phase}"
+                "result": f"Reservoir OK: {days_since_change}/{max_days} days for {grow_phase}",
             }
-            
+
         except Exception as e:
             self.logger.error(f"Reservoir rules evaluation failed: {e}")
             return None
-    
+
     async def _check_freeze_status(self, trends: Dict[str, Any]) -> Dict[str, Any]:
         """Check if system should be frozen due to excellent performance"""
         try:
-            health_7day = trends.get('health_7day_avg', 0)
-            ph_in_spec = trends.get('ph_in_spec_7day', 0)
-            ec_in_spec = trends.get('ec_in_spec_7day', 0)
-            
+            health_7day = trends.get("health_7day_avg", 0)
+            ph_in_spec = trends.get("ph_in_spec_7day", 0)
+            ec_in_spec = trends.get("ec_in_spec_7day", 0)
+
             # Check if all metrics are excellent
-            freeze_threshold = self.thresholds['stability_threshold'] * 100  # 95%
-            
+            freeze_threshold = self.thresholds["stability_threshold"] * 100  # 95%
+
             should_freeze = (
-                health_7day >= 0.95 and
-                ph_in_spec >= freeze_threshold and
-                ec_in_spec >= freeze_threshold
+                health_7day >= 0.95
+                and ph_in_spec >= freeze_threshold
+                and ec_in_spec >= freeze_threshold
             )
-            
+
             return {
                 "frozen": should_freeze,
                 "reason": f"Health: {health_7day:.2f}, pH in-spec: {ph_in_spec}%, EC in-spec: {ec_in_spec}%",
-                "freeze_until": (datetime.utcnow() + timedelta(days=self.thresholds['freeze_period_days'])).isoformat() if should_freeze else None
+                "freeze_until": (
+                    datetime.utcnow()
+                    + timedelta(days=self.thresholds["freeze_period_days"])
+                ).isoformat()
+                if should_freeze
+                else None,
             }
-            
+
         except Exception as e:
             self.logger.error(f"Freeze status check failed: {e}")
             return {"frozen": False, "error": str(e)}
-    
-    async def _check_rollback_required(self, current_kpis: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def _check_rollback_required(
+        self, current_kpis: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Check if recent config changes caused degradation"""
         try:
             # Get recent config changes and KPI history
-            rollback_hours = self.thresholds['rollback_check_hours']
-            
-            # This would check if KPIs degraded significantly after config change
-            # For now, implement basic health score check
-            health_score = current_kpis.get('health_score', 1.0)
-            
-            if health_score < 0.6:  # Significant degradation
+            rollback_hours = self.thresholds["rollback_check_hours"]
+
+            health_score = current_kpis.get("health_score", 1.0)
+
+            # Check for degradation shortly after a config change
+            if self._last_config_change_time and self._previous_kpis:
+                if datetime.utcnow() - self._last_config_change_time < timedelta(
+                    hours=rollback_hours
+                ):
+                    for key in ["health_score", "ph_in_spec", "ec_in_spec"]:
+                        prev = self._previous_kpis.get(key)
+                        curr = current_kpis.get(key)
+                        if prev is not None and curr is not None and curr < prev:
+                            return {
+                                "required": True,
+                                "reason": f"{key} worsened from {prev} to {curr}",
+                                "rollback_to": "previous_config",
+                            }
+
+            if health_score < 0.6:  # Significant degradation regardless of change
                 return {
                     "required": True,
                     "reason": f"Health score {health_score} indicates significant degradation",
-                    "rollback_to": "previous_stable_config"
+                    "rollback_to": "previous_stable_config",
                 }
-            
+
             return {"required": False}
-            
+
         except Exception as e:
             self.logger.error(f"Rollback check failed: {e}")
             return {"required": False, "error": str(e)}
-    
+
     def _calculate_ph_down_dosage(self, ph_adjustment: float) -> float:
         """Calculate pH down dosage in ml"""
         # Empirical formula: 1ml per 0.1 pH reduction per 10L
-        reservoir_volume = self.config.get('reservoir_volume_l', 20)
+        reservoir_volume = self.config.get("reservoir_volume_l", 20)
         return (ph_adjustment / 0.1) * (reservoir_volume / 10)
-    
+
     def _calculate_ph_up_dosage(self, ph_adjustment: float) -> float:
         """Calculate pH up dosage in ml"""
         # pH up typically more concentrated than pH down
-        reservoir_volume = self.config.get('reservoir_volume_l', 20)
+        reservoir_volume = self.config.get("reservoir_volume_l", 20)
         return (ph_adjustment / 0.1) * (reservoir_volume / 10) * 0.7
-    
-    def _calculate_nutrient_dosage(self, ec_adjustment: float, increase: bool = True) -> float:
+
+    def _calculate_nutrient_dosage(
+        self, ec_adjustment: float, increase: bool = True
+    ) -> float:
         """Calculate nutrient dosage to achieve EC adjustment"""
         # Empirical formula: ~5ml per 0.1 EC increase per 10L
-        reservoir_volume = self.config.get('reservoir_volume_l', 20)
+        reservoir_volume = self.config.get("reservoir_volume_l", 20)
         base_dosage = (ec_adjustment / 0.1) * 5 * (reservoir_volume / 10)
-        
+
         return base_dosage if increase else base_dosage * 0.5  # Dilution is harder
-    
+
     def _is_dosage_safe(self, pump_type: str, dosage_ml: float) -> bool:
         """Check if dosage is within safety limits"""
-        max_single = self.safety_limits.get('max_single_dose_ml', 50)
-        
-        if pump_type == 'ph_pump':
+        max_single = self.safety_limits.get("max_single_dose_ml", 50)
+
+        if pump_type == "ph_pump":
             max_single = min(max_single, 20)  # pH pump has lower limit
-        
+
         return 0 < dosage_ml <= max_single
-    
-    async def apply_stable_unless_better_logic(self, proposed_actions: Dict[str, Any],
-                                             current_performance: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def apply_stable_unless_better_logic(
+        self, proposed_actions: Dict[str, Any], current_performance: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Apply stable-unless-better filter to proposed actions"""
         try:
             # If current performance is good, reduce action aggressiveness
-            health_score = current_performance.get('health_score', 0.8)
-            
+            health_score = current_performance.get("health_score", 0.8)
+
             if health_score > 0.9:  # Excellent performance
                 # Reduce dosing amounts by 50%
                 filtered_actions = {}
                 for action_type, action_data in proposed_actions.items():
-                    if action_type == 'dose':
+                    if action_type == "dose":
                         filtered_actions[action_type] = {}
                         for pump, dose_data in action_data.items():
-                            if isinstance(dose_data, dict) and 'ml' in dose_data:
-                                filtered_ml = dose_data['ml'] * 0.5
+                            if isinstance(dose_data, dict) and "ml" in dose_data:
+                                filtered_ml = dose_data["ml"] * 0.5
                                 filtered_actions[action_type][pump] = {
-                                    'ml': round(filtered_ml, 1),
-                                    'reason': f"Reduced dose (stable system): {dose_data.get('reason', '')}"
+                                    "ml": round(filtered_ml, 1),
+                                    "reason": f"Reduced dose (stable system): {dose_data.get('reason', '')}",
                                 }
                     else:
                         filtered_actions[action_type] = action_data
-                
+
                 return {
                     "filtered_actions": filtered_actions,
                     "stability_factor": 0.5,
-                    "reason": f"High performance ({health_score:.2f}) - reduced intervention"
+                    "reason": f"High performance ({health_score:.2f}) - reduced intervention",
                 }
-            
+
             elif health_score > 0.8:  # Good performance
                 # Slight reduction
                 filtered_actions = {}
                 for action_type, action_data in proposed_actions.items():
-                    if action_type == 'dose':
+                    if action_type == "dose":
                         filtered_actions[action_type] = {}
                         for pump, dose_data in action_data.items():
-                            if isinstance(dose_data, dict) and 'ml' in dose_data:
-                                filtered_ml = dose_data['ml'] * 0.8
+                            if isinstance(dose_data, dict) and "ml" in dose_data:
+                                filtered_ml = dose_data["ml"] * 0.8
                                 filtered_actions[action_type][pump] = {
-                                    'ml': round(filtered_ml, 1),
-                                    'reason': f"Slightly reduced (good system): {dose_data.get('reason', '')}"
+                                    "ml": round(filtered_ml, 1),
+                                    "reason": f"Slightly reduced (good system): {dose_data.get('reason', '')}",
                                 }
                     else:
                         filtered_actions[action_type] = action_data
-                
+
                 return {
                     "filtered_actions": filtered_actions,
                     "stability_factor": 0.8,
-                    "reason": f"Good performance ({health_score:.2f}) - slight reduction"
+                    "reason": f"Good performance ({health_score:.2f}) - slight reduction",
                 }
-            
+
             else:  # Poor performance - allow full actions
                 return {
                     "filtered_actions": proposed_actions,
                     "stability_factor": 1.0,
-                    "reason": f"Poor performance ({health_score:.2f}) - full intervention needed"
+                    "reason": f"Poor performance ({health_score:.2f}) - full intervention needed",
                 }
-                
+
         except Exception as e:
             self.logger.error(f"Stable-unless-better logic failed: {e}")
             return {
                 "filtered_actions": proposed_actions,
                 "stability_factor": 1.0,
-                "error": str(e)
+                "error": str(e),
             }

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -3,265 +3,382 @@ Tests for the rules engine and stable-unless-better logic
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
-from datetime import datetime
+import pytest_asyncio
+from unittest.mock import AsyncMock
+from datetime import datetime, timedelta
 
 from app.rules import RulesEngine
-from app.memory.db import Database
+
+
+@pytest_asyncio.fixture
+async def rules_engine(mock_config, temp_db):
+    """Create rules engine instance"""
+    await temp_db.init()
+    return RulesEngine(mock_config, temp_db)
 
 
 class TestRulesEngine:
     """Test the rules engine functionality"""
-    
-    @pytest.fixture
-    async def rules_engine(self, mock_config, temp_db):
-        """Create rules engine instance"""
-        await temp_db.init()
-        return RulesEngine(mock_config, temp_db)
-    
+
     @pytest.mark.asyncio
     async def test_ph_adjustment_rule(self, rules_engine, mock_sensor_data):
         """Test pH adjustment rule logic"""
         # Mock 7-day trends indicating poor pH stability
         mock_trends = {
-            'ph_in_spec_7day': 85.0,  # Below 90% threshold
-            'ph_trend': 'decreasing'
+            "ph_in_spec_7day": 85.0,  # Below 90% threshold
+            "ph_trend": "decreasing",
         }
-        
+
         # Mock KPI calculator to return poor pH trends
-        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(return_value=mock_trends)
-        
+        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(
+            return_value=mock_trends
+        )
+
         # Test with high pH requiring adjustment
-        mock_sensor_data['water']['ph'] = 6.8  # Above target of 6.0
-        
-        current_kpis = {'health_score': 0.75}
-        
+        mock_sensor_data["water"]["ph"] = 6.8  # Above target of 6.0
+
+        current_kpis = {"health_score": 0.75}
+
         result = await rules_engine.evaluate_rules(mock_sensor_data, current_kpis)
-        
+
         assert result is not None
-        assert 'rule_evaluations' in result
-        assert 'actions' in result
-        
+        assert "rule_evaluations" in result
+        assert "actions" in result
+
         # Should recommend pH adjustment
-        ph_actions = [r for r in result['rule_evaluations'] if r.get('rule') == 'ph_adjustment']
+        ph_actions = [
+            r for r in result["rule_evaluations"] if r.get("rule") == "ph_adjustment"
+        ]
         if ph_actions:
-            assert 'action' in ph_actions[0]
-            assert 'ph_pump' in ph_actions[0]['action']
-    
+            assert "action" in ph_actions[0]
+            assert "ph_pump" in ph_actions[0]["action"]
+
     @pytest.mark.asyncio
     async def test_ec_adjustment_rule(self, rules_engine, mock_sensor_data):
         """Test EC adjustment rule logic"""
         # Mock trends showing poor EC stability and low health
         mock_trends = {
-            'ec_in_spec_7day': 80.0,  # Below 90% threshold
-            'ml_total_7day': 45.0
+            "ec_in_spec_7day": 80.0,  # Below 90% threshold
+            "ml_total_7day": 45.0,
         }
-        
-        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(return_value=mock_trends)
-        
+
+        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(
+            return_value=mock_trends
+        )
+
         # Test with low EC and low health score
-        mock_sensor_data['water']['ec'] = 1.3  # Below target of 1.6
-        current_kpis = {'health_score': 0.7}  # Below 0.8 threshold
-        
+        mock_sensor_data["water"]["ec"] = 1.3  # Below target of 1.6
+        current_kpis = {"health_score": 0.7}  # Below 0.8 threshold
+
         result = await rules_engine.evaluate_rules(mock_sensor_data, current_kpis)
-        
+
         # Should recommend EC increase
-        ec_actions = [r for r in result['rule_evaluations'] if r.get('rule') == 'ec_increase']
+        ec_actions = [
+            r for r in result["rule_evaluations"] if r.get("rule") == "ec_increase"
+        ]
         if ec_actions:
-            assert 'action' in ec_actions[0]
-            action = ec_actions[0]['action']
-            assert 'pump_a' in action or 'pump_b' in action
-    
+            assert "action" in ec_actions[0]
+            action = ec_actions[0]["action"]
+            assert "pump_a" in action or "pump_b" in action
+
     @pytest.mark.asyncio
     async def test_environmental_control_rules(self, rules_engine, mock_sensor_data):
         """Test environmental control rule logic"""
         # Test high temperature triggering fan control
-        mock_sensor_data['air']['temperature'] = 28.0  # Above target + tolerance
-        current_kpis = {'health_score': 0.8}
-        
+        mock_sensor_data["air"]["temperature"] = 28.0  # Above target + tolerance
+        current_kpis = {"health_score": 0.8}
+
         result = await rules_engine.evaluate_rules(mock_sensor_data, current_kpis)
-        
+
         # Should recommend fan speed increase
-        fan_actions = [r for r in result['rule_evaluations'] if r.get('type') == 'fan']
+        fan_actions = [r for r in result["rule_evaluations"] if r.get("type") == "fan"]
         if fan_actions:
-            assert 'action' in fan_actions[0]
-            assert fan_actions[0]['action']['fan_speed'] > 0
-    
+            assert "action" in fan_actions[0]
+            assert fan_actions[0]["action"]["fan_speed"] > 0
+
     @pytest.mark.asyncio
     async def test_safety_limits_enforcement(self, rules_engine):
         """Test that safety limits are enforced"""
         # Test dosing safety limits
-        assert rules_engine._is_dosage_safe('pump_a', 25.0) == True  # Within limit
-        assert rules_engine._is_dosage_safe('pump_a', 75.0) == False  # Exceeds limit
-        assert rules_engine._is_dosage_safe('ph_pump', 15.0) == True  # Within pH limit
-        assert rules_engine._is_dosage_safe('ph_pump', 25.0) == False  # Exceeds pH limit
-    
+        assert rules_engine._is_dosage_safe("pump_a", 25.0)
+        assert not rules_engine._is_dosage_safe("pump_a", 75.0)
+        assert rules_engine._is_dosage_safe("ph_pump", 15.0)
+        assert not rules_engine._is_dosage_safe("ph_pump", 25.0)
+
     @pytest.mark.asyncio
     async def test_freeze_status_check(self, rules_engine):
         """Test system freeze logic for excellent performance"""
         # Mock excellent performance trends
         excellent_trends = {
-            'health_7day_avg': 0.96,
-            'ph_in_spec_7day': 97.0,
-            'ec_in_spec_7day': 96.0
+            "health_7day_avg": 0.96,
+            "ph_in_spec_7day": 97.0,
+            "ec_in_spec_7day": 96.0,
         }
-        
+
         freeze_status = await rules_engine._check_freeze_status(excellent_trends)
-        
-        assert freeze_status['frozen'] == True
-        assert 'freeze_until' in freeze_status
-        assert freeze_status['reason'] is not None
-    
+
+        assert freeze_status["frozen"]
+        assert "freeze_until" in freeze_status
+        assert freeze_status["reason"] is not None
+
     @pytest.mark.asyncio
     async def test_stable_unless_better_logic(self, rules_engine):
         """Test stable-unless-better filtering"""
         # Mock proposed actions
         proposed_actions = {
-            'dose': {
-                'pump_a': {'ml': 10.0, 'reason': 'Test dosing'},
-                'pump_b': {'ml': 5.0, 'reason': 'Test dosing'}
+            "dose": {
+                "pump_a": {"ml": 10.0, "reason": "Test dosing"},
+                "pump_b": {"ml": 5.0, "reason": "Test dosing"},
             }
         }
-        
+
         # Test with excellent performance (should reduce actions)
-        excellent_performance = {'health_score': 0.95}
-        
+        excellent_performance = {"health_score": 0.95}
+
         result = await rules_engine.apply_stable_unless_better_logic(
             proposed_actions, excellent_performance
         )
-        
-        assert result['stability_factor'] == 0.5  # Should reduce by 50%
-        assert result['filtered_actions']['dose']['pump_a']['ml'] == 5.0  # Reduced
-        
+
+        assert result["stability_factor"] == 0.5  # Should reduce by 50%
+        assert result["filtered_actions"]["dose"]["pump_a"]["ml"] == 5.0  # Reduced
+
         # Test with poor performance (should allow full actions)
-        poor_performance = {'health_score': 0.6}
-        
+        poor_performance = {"health_score": 0.6}
+
         result = await rules_engine.apply_stable_unless_better_logic(
             proposed_actions, poor_performance
         )
-        
-        assert result['stability_factor'] == 1.0  # No reduction
-        assert result['filtered_actions']['dose']['pump_a']['ml'] == 10.0  # Full amount
-    
+
+        assert result["stability_factor"] == 1.0  # No reduction
+        assert result["filtered_actions"]["dose"]["pump_a"]["ml"] == 10.0  # Full amount
+
     def test_ph_dosage_calculations(self, rules_engine):
         """Test pH dosage calculation formulas"""
         # Test pH down calculation
         dosage_down = rules_engine._calculate_ph_down_dosage(0.2)  # 0.2 pH units
         assert dosage_down > 0
         assert dosage_down <= 50  # Should be reasonable amount
-        
+
         # Test pH up calculation
         dosage_up = rules_engine._calculate_ph_up_dosage(0.2)
         assert dosage_up > 0
         assert dosage_up < dosage_down  # pH up typically more concentrated
-    
+
     def test_nutrient_dosage_calculations(self, rules_engine):
         """Test nutrient dosage calculation formulas"""
         # Test EC increase dosage
         dosage_increase = rules_engine._calculate_nutrient_dosage(0.1, increase=True)
         assert dosage_increase > 0
         assert dosage_increase <= 50  # Should be reasonable
-        
+
         # Test EC decrease dosage (dilution)
         dosage_decrease = rules_engine._calculate_nutrient_dosage(0.1, increase=False)
         assert dosage_decrease > 0
         assert dosage_decrease < dosage_increase  # Dilution harder than concentration
 
+    @pytest.mark.asyncio
+    async def test_ph_target_nudge_rule(self, rules_engine, mock_sensor_data):
+        """pH target nudging when stability is poor"""
+        mock_trends = {"ph_in_spec_7day": 80.0, "ph_trend": "increasing"}
+        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(
+            return_value=mock_trends
+        )
+
+        result = await rules_engine.evaluate_rules(
+            mock_sensor_data, {"health_score": 0.9}
+        )
+
+        nudge = [
+            r for r in result["rule_evaluations"] if r.get("rule") == "ph_target_nudge"
+        ]
+        assert nudge
+        assert nudge[0]["action"]["ph_target"] == 6.1
+
+    @pytest.mark.asyncio
+    async def test_ec_target_raise_rule(self, rules_engine, mock_sensor_data):
+        """EC target raises when performance is poor"""
+        mock_trends = {"ec_in_spec_7day": 80.0, "ml_total_7day": 30.0}
+        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(
+            return_value=mock_trends
+        )
+
+        result = await rules_engine.evaluate_rules(
+            mock_sensor_data, {"health_score": 0.7}
+        )
+
+        raise_act = [
+            r for r in result["rule_evaluations"] if r.get("rule") == "ec_target_raise"
+        ]
+        assert raise_act
+        assert raise_act[0]["action"]["ec_target"] == 1.7
+
+    @pytest.mark.asyncio
+    async def test_ec_target_lower_rule(self, rules_engine, mock_sensor_data):
+        """EC target lowered when dosing high"""
+        mock_trends = {"ec_in_spec_7day": 96.0, "ml_total_7day": 70.0}
+        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(
+            return_value=mock_trends
+        )
+
+        result = await rules_engine.evaluate_rules(
+            mock_sensor_data, {"health_score": 0.85}
+        )
+
+        lower_act = [
+            r for r in result["rule_evaluations"] if r.get("rule") == "ec_decrease"
+        ]
+        assert lower_act
+        assert lower_act[0]["action"]["ec_target"] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_lux_ec_temp_lower(self, rules_engine, mock_sensor_data):
+        """Temporary EC reduction when high light and EC"""
+        mock_trends = {"ec_in_spec_7day": 95.0, "ml_total_7day": 40.0}
+        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(
+            return_value=mock_trends
+        )
+        rules_engine.db.get_recent_sensor_data = AsyncMock(
+            return_value=[{"ec": 2.1}, {"ec": 2.1}, {"ec": 2.1}]
+        )
+        mock_sensor_data["light"]["lux"] = 32000
+
+        result = await rules_engine.evaluate_rules(
+            mock_sensor_data, {"health_score": 0.85}
+        )
+
+        action = [
+            r
+            for r in result["rule_evaluations"]
+            if r.get("rule") == "lux_ec_temp_lower"
+        ]
+        assert action
+        assert action[0]["action"]["ec_target"] == 1.5
+
 
 class TestRuleValidation:
     """Test rule validation and edge cases"""
-    
+
     @pytest.mark.asyncio
     async def test_missing_sensor_data(self, rules_engine):
         """Test handling of missing sensor data"""
         incomplete_data = {
             "timestamp": datetime.utcnow().isoformat(),
             "water": {"ph": None, "ec": 1.6},  # Missing pH
-            "air": {"temperature": 22}  # Missing other air data
+            "air": {"temperature": 22},  # Missing other air data
         }
-        
-        current_kpis = {'health_score': 0.8}
-        
+
+        current_kpis = {"health_score": 0.8}
+
         # Should not crash with incomplete data
         result = await rules_engine.evaluate_rules(incomplete_data, current_kpis)
-        
+
         assert result is not None
-        assert 'error' not in result
-    
+        assert "error" not in result
+
     @pytest.mark.asyncio
     async def test_extreme_sensor_values(self, rules_engine, mock_sensor_data):
         """Test handling of extreme sensor values"""
         # Test with extreme values
-        mock_sensor_data['water']['ph'] = 3.0  # Extremely low
-        mock_sensor_data['water']['ec'] = 4.0  # Extremely high
-        mock_sensor_data['air']['temperature'] = 40.0  # Very high
-        
-        current_kpis = {'health_score': 0.2}  # Very poor
-        
+        mock_sensor_data["water"]["ph"] = 3.0  # Extremely low
+        mock_sensor_data["water"]["ec"] = 4.0  # Extremely high
+        mock_sensor_data["air"]["temperature"] = 40.0  # Very high
+
+        current_kpis = {"health_score": 0.2}  # Very poor
+
         result = await rules_engine.evaluate_rules(mock_sensor_data, current_kpis)
-        
+
         # Should handle extreme values gracefully
         assert result is not None
-        assert result.get('rollback_required', {}).get('required') == True  # Should trigger rollback
-    
+        assert result.get("rollback_required", {}).get("required")
+
+    @pytest.mark.asyncio
+    async def test_rollback_after_config_change(self, rules_engine, mock_sensor_data):
+        """Rollback triggered when KPIs worsen after a change"""
+        rules_engine._last_config_change_time = datetime.utcnow() - timedelta(hours=1)
+        rules_engine._previous_kpis = {
+            "health_score": 0.9,
+            "ph_in_spec": 0.95,
+            "ec_in_spec": 0.9,
+        }
+
+        mock_trends = {
+            "ph_in_spec_7day": 95.0,
+            "ec_in_spec_7day": 95.0,
+            "ml_total_7day": 40.0,
+        }
+        rules_engine.kpi_calc.calculate_7day_trends = AsyncMock(
+            return_value=mock_trends
+        )
+
+        current_kpis = {"health_score": 0.85, "ph_in_spec": 0.9, "ec_in_spec": 0.88}
+        result = await rules_engine.evaluate_rules(mock_sensor_data, current_kpis)
+
+        assert result["rollback_required"]["required"]
+
     def test_dosage_safety_edge_cases(self, rules_engine):
         """Test dosage safety with edge cases"""
         # Test zero dosage
-        assert rules_engine._is_dosage_safe('pump_a', 0.0) == False  # Zero not allowed
-        
+        assert not rules_engine._is_dosage_safe("pump_a", 0.0)  # Zero not allowed
+
         # Test negative dosage
-        assert rules_engine._is_dosage_safe('pump_a', -5.0) == False
-        
+        assert not rules_engine._is_dosage_safe("pump_a", -5.0)
+
         # Test exact limit
-        assert rules_engine._is_dosage_safe('pump_a', 50.0) == True  # Exactly at limit
-        
+        assert rules_engine._is_dosage_safe("pump_a", 50.0)  # Exactly at limit
+
         # Test very small dosage
-        assert rules_engine._is_dosage_safe('pump_a', 0.1) == True
+        assert rules_engine._is_dosage_safe("pump_a", 0.1)
 
 
 @pytest.mark.integration
 class TestRulesIntegration:
     """Integration tests for rules engine with other components"""
-    
+
     @pytest.mark.asyncio
-    async def test_full_rules_cycle_with_database(self, rules_engine, mock_sensor_data, temp_db):
+    async def test_full_rules_cycle_with_database(
+        self, rules_engine, mock_sensor_data, temp_db
+    ):
         """Test complete rules evaluation cycle with database storage"""
         await temp_db.init()
-        
+
         # Store some historical data first
         for i in range(10):
             await temp_db.store_sensor_reading(mock_sensor_data)
-            await temp_db.store_actuator_action({
-                'timestamp': datetime.utcnow().isoformat(),
-                'action_type': 'test',
-                'pump_a_ml': 2.0,
-                'reason': 'test action'
-            })
-        
-        current_kpis = {'health_score': 0.8}
-        
+            await temp_db.store_actuator_action(
+                {
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "action_type": "test",
+                    "pump_a_ml": 2.0,
+                    "reason": "test action",
+                }
+            )
+
+        current_kpis = {"health_score": 0.8}
+
         result = await rules_engine.evaluate_rules(mock_sensor_data, current_kpis)
-        
+
         assert result is not None
-        assert 'rule_evaluations' in result
-        assert 'actions' in result
-        assert 'freeze_status' in result
-    
+        assert "rule_evaluations" in result
+        assert "actions" in result
+        assert "freeze_status" in result
+
     @pytest.mark.asyncio
-    async def test_rules_with_kpi_calculation(self, rules_engine, mock_sensor_data, temp_db):
+    async def test_rules_with_kpi_calculation(
+        self, rules_engine, mock_sensor_data, temp_db
+    ):
         """Test rules engine integration with KPI calculations"""
         await temp_db.init()
-        
+
         # Create mock KPI data
         kpis = {
-            'health_score': 0.85,
-            'ph_in_spec': 0.9,
-            'ec_in_spec': 0.88,
-            'days_since_reservoir_change': 10
+            "health_score": 0.85,
+            "ph_in_spec": 0.9,
+            "ec_in_spec": 0.88,
+            "days_since_reservoir_change": 10,
         }
-        
+
         result = await rules_engine.evaluate_rules(mock_sensor_data, kpis)
-        
+
         # Verify the rules engine used the KPI data appropriately
         assert result is not None
-        assert len(result['rule_evaluations']) > 0
+        assert len(result["rule_evaluations"]) > 0


### PR DESCRIPTION
## Summary
- implement new nutrient control rules in rules engine
- support pH target nudging
- raise/lower EC targets and temporary reductions
- add rollback detection
- extend unit tests for new behaviours

## Testing
- `pre-commit run --files app/rules.py tests/test_rules.py` *(fails: tests errored)*

------
https://chatgpt.com/codex/tasks/task_e_68898ab4fba88329af328a22d2ba09a6