### PR TITLE
Add missing aiosqlite requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ pyserial==3.5
 requests==2.32.3
 jsonschema==4.23.0
 pre-commit==4.0.1
+aiosqlite==0.21.0


### PR DESCRIPTION
## Summary
- add `aiosqlite` to requirements.txt

## Testing
- `make test` *(fails: Could not find a version that satisfies adafruit-circuitpython-dht==3.7.9)*

------
https://chatgpt.com/codex/tasks/task_e_6889914b688883299faf7fc833e44e0e