### PR TITLE
Fix in-memory database stats

### DIFF
--- a/app/memory/db.py
+++ b/app/memory/db.py
@@ -395,7 +395,10 @@ class Database:
                 stats[f"{table}_count"] = count[0]
             
             # Database file size
-            stats['db_size_mb'] = round(self.db_path.stat().st_size / (1024 * 1024), 2)
+            if self.db_path.is_file():
+                stats['db_size_mb'] = round(self.db_path.stat().st_size / (1024 * 1024), 2)
+            else:
+                stats['db_size_mb'] = 0
             
             return stats
             


### PR DESCRIPTION
## Summary
- handle in-memory database paths in `get_database_stats`

## Testing
- `make lint` *(fails: adafruit-circuitpython-dht==3.7.9 not available)*
- `make test` *(fails: adafruit-circuitpython-dht==3.7.9 not available)*

------
https://chatgpt.com/codex/tasks/task_e_68899153efb0832996eb27e945884f60