### PR TITLE
Update shadow day tests for warning-based violations

### DIFF
--- a/scripts/shadow_validator.py
+++ b/scripts/shadow_validator.py
@@ -259,6 +259,7 @@ class ShadowValidator:
             safety_violation = self._check_safety_violations(reading)
             if safety_violation:
                 self.results["safety_violations"] += 1
+                # Safety violations are tracked but not treated as script errors
                 self.results["warnings"].append(
                     f"Safety violation at reading {index}: {safety_violation}"
                 )

--- a/scripts/shadow_validator.py
+++ b/scripts/shadow_validator.py
@@ -27,7 +27,7 @@ from app.utils import load_config
 
 class ShadowValidator:
     """Shadow validation system for testing with historical data"""
-    
+
     def __init__(self, data_file: str = None):
         self.data_file = data_file or "tests/data/sensors_sample.csv"
         self.config = load_config()
@@ -38,7 +38,7 @@ class ShadowValidator:
         self.rules_engine = None
         self.kpi_calc = None
         self.logger = logging.getLogger(__name__)
-        
+
         # Validation results
         self.results = {
             "start_time": datetime.utcnow().isoformat(),
@@ -48,47 +48,55 @@ class ShadowValidator:
             "actions_taken": 0,
             "errors": [],
             "warnings": [],
-            "performance_metrics": {}
+            "performance_metrics": {},
         }
-    
+
     async def initialize(self):
         """Initialize all components in mock mode"""
         try:
             self.db = Database(":memory:")  # Use in-memory DB for testing
             await self.db.init()
-            
+
             # All components in mock mode for validation
             self.sensors = SensorInterface(mock=True)
             self.actuators = ActuatorController(mock=True)
             self.kpi_calc = KPICalculator(self.db)
             self.rules_engine = RulesEngine(self.config, self.db)
-            
+
             # LLM agent in test mode (no API calls)
             try:
                 self.llm_agent = LLMAgent()
             except Exception as e:
                 self.logger.warning(f"LLM agent not available for validation: {e}")
                 self.llm_agent = None
-            
+
             self.logger.info("Shadow validator initialized")
-            
+
         except Exception as e:
             self.logger.error(f"Shadow validator initialization failed: {e}")
             raise
-    
+
     async def run_validation(self) -> dict:
-        """Run complete shadow validation"""
+        """Run complete shadow validation
+
+        Safety violations encountered during processing are logged in the
+        ``warnings`` list but do not cause the overall ``success`` flag to
+        be false. The method returns a dictionary containing ``success``,
+        ``validation_passed``, and all collected metrics.
+        """
         try:
-            self.logger.info(f"Starting shadow validation with data file: {self.data_file}")
-            
+            self.logger.info(
+                f"Starting shadow validation with data file: {self.data_file}"
+            )
+
             # Load sensor data
             sensor_readings = self._load_sensor_data()
-            
+
             if not sensor_readings:
                 raise ValueError("No sensor data loaded")
-            
+
             self.results["total_readings"] = len(sensor_readings)
-            
+
             # Process each reading
             for i, reading in enumerate(sensor_readings):
                 try:
@@ -96,41 +104,41 @@ class ShadowValidator:
                 except Exception as e:
                     self.logger.error(f"Error processing reading {i}: {e}")
                     self.results["errors"].append(f"Reading {i}: {str(e)}")
-            
+
             # Calculate final metrics
             await self._calculate_final_metrics()
-            
+
             self.results["end_time"] = datetime.utcnow().isoformat()
             self.results["success"] = len(self.results["errors"]) == 0
-            
+
             # Validate results against requirements
             validation_passed = self._validate_requirements()
             self.results["validation_passed"] = validation_passed
-            
+
             self.logger.info(f"Shadow validation completed: {validation_passed}")
-            
+
             return self.results
-            
+
         except Exception as e:
             self.logger.error(f"Shadow validation failed: {e}")
             self.results["error"] = str(e)
             self.results["success"] = False
             return self.results
-    
+
     def _load_sensor_data(self) -> list:
         """Load sensor data from CSV file"""
         readings = []
-        
+
         try:
             data_path = Path(self.data_file)
-            
+
             if not data_path.exists():
                 # Create sample data if file doesn't exist
                 self._create_sample_data(data_path)
-            
-            with open(data_path, 'r') as f:
+
+            with open(data_path, "r") as f:
                 reader = csv.DictReader(f)
-                
+
                 for row in reader:
                     # Convert string values to appropriate types
                     reading = {
@@ -141,70 +149,80 @@ class ShadowValidator:
                             "temperature": float(row["water_temp"]),
                             "turbidity": float(row["turbidity"]),
                             "level_high": row["level_high"].lower() == "true",
-                            "level_low": row["level_low"].lower() == "true"
+                            "level_low": row["level_low"].lower() == "true",
                         },
                         "air": {
                             "temperature": float(row["air_temp"]),
                             "humidity": float(row["humidity"]),
                             "pressure": float(row["pressure"]),
-                            "co2": int(row["co2"])
+                            "co2": int(row["co2"]),
                         },
-                        "root": {
-                            "temperature": float(row["root_temp"])
-                        },
+                        "root": {"temperature": float(row["root_temp"])},
                         "light": {
                             "lux": float(row["lux"]),
-                            "led_power": int(row["led_power"])
-                        }
+                            "led_power": int(row["led_power"]),
+                        },
                     }
-                    
+
                     readings.append(reading)
-            
+
             self.logger.info(f"Loaded {len(readings)} sensor readings")
             return readings
-            
+
         except Exception as e:
             self.logger.error(f"Failed to load sensor data: {e}")
             return []
-    
+
     def _create_sample_data(self, data_path: Path):
         """Create sample sensor data for testing"""
         import random
         from datetime import timedelta
-        
+
         data_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Generate 24 hours of sample data (1440 readings at 1-minute intervals)
         start_time = datetime.utcnow() - timedelta(days=1)
-        
-        with open(data_path, 'w', newline='') as f:
+
+        with open(data_path, "w", newline="") as f:
             fieldnames = [
-                "timestamp", "ph", "ec", "water_temp", "turbidity", "level_high", "level_low",
-                "air_temp", "humidity", "pressure", "co2", "root_temp", "lux", "led_power"
+                "timestamp",
+                "ph",
+                "ec",
+                "water_temp",
+                "turbidity",
+                "level_high",
+                "level_low",
+                "air_temp",
+                "humidity",
+                "pressure",
+                "co2",
+                "root_temp",
+                "lux",
+                "led_power",
             ]
-            
+
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
-            
+
             for i in range(1440):  # 24 hours of minute-by-minute data
                 timestamp = start_time + timedelta(minutes=i)
-                
+
                 # Simulate realistic but occasionally problematic values
                 ph_base = 6.0
                 ec_base = 1.6
-                
+
                 # Add some drift and noise
                 if i > 720:  # After 12 hours, introduce some drift
                     ph_base += random.gauss(0, 0.1)
                     ec_base += random.gauss(0, 0.05)
-                
+
                 # Occasionally create out-of-spec conditions
                 if random.random() < 0.05:  # 5% chance of issues
                     ph_base += random.choice([-0.5, 0.5])
-                
+
                 if random.random() < 0.03:  # 3% chance of EC issues
                     ec_base += random.choice([-0.3, 0.3])
-                
+
                 row = {
                     "timestamp": timestamp.isoformat(),
                     "ph": round(max(4.0, min(8.0, ph_base + random.gauss(0, 0.05))), 2),
@@ -219,24 +237,24 @@ class ShadowValidator:
                     "co2": max(300, min(1500, int(800 + random.gauss(0, 100)))),
                     "root_temp": round(21 + random.gauss(0, 0.5), 1),
                     "lux": max(0, int(25000 + random.gauss(0, 5000))),
-                    "led_power": 80 if 6 <= timestamp.hour <= 22 else 0
+                    "led_power": 80 if 6 <= timestamp.hour <= 22 else 0,
                 }
-                
+
                 writer.writerow(row)
-        
+
         self.logger.info(f"Created sample data file: {data_path}")
-    
+
     async def _process_reading(self, reading: dict, index: int):
         """Process a single sensor reading"""
         try:
             # Store reading in database
             await self.db.store_sensor_reading(reading)
-            
+
             # Check if reading is in spec
             in_spec = self._check_reading_in_spec(reading)
             if in_spec:
                 self.results["in_spec_readings"] += 1
-            
+
             # Check for safety violations
             safety_violation = self._check_safety_violations(reading)
             if safety_violation:
@@ -244,190 +262,233 @@ class ShadowValidator:
                 self.results["warnings"].append(
                     f"Safety violation at reading {index}: {safety_violation}"
                 )
-            
+
             # Run control logic every 10 readings (simulating 10-minute intervals)
             if index % 10 == 0:
                 await self._run_control_logic(reading)
-            
+
         except Exception as e:
             self.logger.error(f"Error processing reading {index}: {e}")
             raise
-    
+
     def _check_reading_in_spec(self, reading: dict) -> bool:
         """Check if reading is within specification"""
         try:
-            targets = self.config.get('targets', {})
-            
-            water = reading.get('water', {})
-            air = reading.get('air', {})
-            
-            ph_in_spec = targets.get('ph_min', 5.5) <= water.get('ph', 0) <= targets.get('ph_max', 6.5)
-            ec_in_spec = targets.get('ec_min', 1.2) <= water.get('ec', 0) <= targets.get('ec_max', 2.0)
-            temp_in_spec = targets.get('temp_min', 18) <= air.get('temperature', 0) <= targets.get('temp_max', 26)
-            
+            targets = self.config.get("targets", {})
+
+            water = reading.get("water", {})
+            air = reading.get("air", {})
+
+            ph_in_spec = (
+                targets.get("ph_min", 5.5)
+                <= water.get("ph", 0)
+                <= targets.get("ph_max", 6.5)
+            )
+            ec_in_spec = (
+                targets.get("ec_min", 1.2)
+                <= water.get("ec", 0)
+                <= targets.get("ec_max", 2.0)
+            )
+            temp_in_spec = (
+                targets.get("temp_min", 18)
+                <= air.get("temperature", 0)
+                <= targets.get("temp_max", 26)
+            )
+
             return ph_in_spec and ec_in_spec and temp_in_spec
-            
+
         except Exception:
             return False
-    
+
     def _check_safety_violations(self, reading: dict) -> str:
         """Check for safety limit violations"""
         try:
-            water = reading.get('water', {})
-            air = reading.get('air', {})
-            
+            water = reading.get("water", {})
+            air = reading.get("air", {})
+
             # Check absolute safety limits
-            if water.get('ph', 7) < 4.0 or water.get('ph', 7) > 8.0:
+            if water.get("ph", 7) < 4.0 or water.get("ph", 7) > 8.0:
                 return f"pH {water.get('ph')} outside safety limits (4.0-8.0)"
-            
-            if water.get('ec', 1.6) < 0.5 or water.get('ec', 1.6) > 3.0:
+
+            if water.get("ec", 1.6) < 0.5 or water.get("ec", 1.6) > 3.0:
                 return f"EC {water.get('ec')} outside safety limits (0.5-3.0)"
-            
-            if air.get('temperature', 22) < 10 or air.get('temperature', 22) > 35:
+
+            if air.get("temperature", 22) < 10 or air.get("temperature", 22) > 35:
                 return f"Temperature {air.get('temperature')}°C outside safety limits (10-35°C)"
-            
-            if not water.get('level_high', True) and not water.get('level_low', True):
+
+            if not water.get("level_high", True) and not water.get("level_low", True):
                 return "Critical water level - both sensors indicate low"
-            
+
             return None
-            
+
         except Exception as e:
             return f"Safety check error: {e}"
-    
+
     async def _run_control_logic(self, reading: dict):
         """Run control logic for a reading"""
         try:
             # Calculate KPIs
-            kpis = await self.kpi_calc.calculate_current_kpis(reading, self.config.get('targets', {}))
-            
+            kpis = await self.kpi_calc.calculate_current_kpis(
+                reading, self.config.get("targets", {})
+            )
+
             # Run rules engine
             rules_result = await self.rules_engine.evaluate_rules(reading, kpis)
-            
+
             # Execute any recommended actions
-            actions = rules_result.get('actions', {})
-            
+            actions = rules_result.get("actions", {})
+
             if actions:
                 self.results["actions_taken"] += 1
-                
+
                 # Simulate action execution
-                if 'dose' in actions:
-                    dose_result = await self.actuators.dose_nutrients(actions['dose'])
-                    if dose_result.get('errors'):
-                        self.results["errors"].extend(dose_result['errors'])
-                
-                if 'fan' in actions:
-                    await self.actuators.control_fan(actions['fan'].get('fan_speed', 0))
-                
-                if 'led' in actions:
-                    await self.actuators.control_led(actions['led'].get('led_power', 0))
-            
+                if "dose" in actions:
+                    dose_result = await self.actuators.dose_nutrients(actions["dose"])
+                    if dose_result.get("errors"):
+                        self.results["errors"].extend(dose_result["errors"])
+
+                if "fan" in actions:
+                    await self.actuators.control_fan(actions["fan"].get("fan_speed", 0))
+
+                if "led" in actions:
+                    await self.actuators.control_led(actions["led"].get("led_power", 0))
+
         except Exception as e:
             self.logger.error(f"Control logic error: {e}")
             self.results["errors"].append(f"Control logic error: {str(e)}")
-    
+
     async def _calculate_final_metrics(self):
         """Calculate final performance metrics"""
         try:
             total_readings = self.results["total_readings"]
             in_spec_readings = self.results["in_spec_readings"]
-            
+
             if total_readings > 0:
                 in_spec_percentage = (in_spec_readings / total_readings) * 100
-                
+
                 self.results["performance_metrics"] = {
                     "in_spec_percentage": round(in_spec_percentage, 2),
-                    "safety_violation_rate": round((self.results["safety_violations"] / total_readings) * 100, 2),
-                    "action_rate": round((self.results["actions_taken"] / (total_readings / 10)) * 100, 2),
-                    "error_rate": round((len(self.results["errors"]) / total_readings) * 100, 2)
+                    "safety_violation_rate": round(
+                        (self.results["safety_violations"] / total_readings) * 100, 2
+                    ),
+                    "action_rate": round(
+                        (self.results["actions_taken"] / (total_readings / 10)) * 100, 2
+                    ),
+                    "error_rate": round(
+                        (len(self.results["errors"]) / total_readings) * 100, 2
+                    ),
                 }
-            
+
             # Get database statistics
             db_stats = await self.db.get_database_stats()
             self.results["database_stats"] = db_stats
-            
+
         except Exception as e:
             self.logger.error(f"Final metrics calculation failed: {e}")
-    
+
     def _validate_requirements(self) -> bool:
         """Validate against system requirements"""
         try:
             metrics = self.results["performance_metrics"]
-            
+
             # Requirement: ≥95% readings in-spec
             in_spec_ok = metrics.get("in_spec_percentage", 0) >= 95.0
-            
+
             # Requirement: 0 safety limit breaches
             safety_ok = self.results["safety_violations"] == 0
-            
+
             # Requirement: Error rate < 1%
             error_ok = metrics.get("error_rate", 100) < 1.0
-            
+
             self.results["requirements_check"] = {
-                "in_spec_requirement": {"passed": in_spec_ok, "value": metrics.get("in_spec_percentage", 0), "threshold": 95.0},
-                "safety_requirement": {"passed": safety_ok, "value": self.results["safety_violations"], "threshold": 0},
-                "error_requirement": {"passed": error_ok, "value": metrics.get("error_rate", 100), "threshold": 1.0}
+                "in_spec_requirement": {
+                    "passed": in_spec_ok,
+                    "value": metrics.get("in_spec_percentage", 0),
+                    "threshold": 95.0,
+                },
+                "safety_requirement": {
+                    "passed": safety_ok,
+                    "value": self.results["safety_violations"],
+                    "threshold": 0,
+                },
+                "error_requirement": {
+                    "passed": error_ok,
+                    "value": metrics.get("error_rate", 100),
+                    "threshold": 1.0,
+                },
             }
-            
+
             return in_spec_ok and safety_ok and error_ok
-            
+
         except Exception as e:
             self.logger.error(f"Requirements validation failed: {e}")
             return False
-    
+
     async def cleanup(self):
         """Cleanup resources"""
         if self.actuators:
             await self.actuators.shutdown()
-        
+
         if self.db:
             await self.db.close()
-        
+
         self.logger.info("Shadow validator cleanup complete")
 
 
 async def main():
     """Main execution function"""
-    parser = argparse.ArgumentParser(description='Shadow validation for hydroponic controller')
-    parser.add_argument('--data', default='tests/data/sensors_sample.csv', 
-                       help='CSV file with sensor data (default: tests/data/sensors_sample.csv)')
-    parser.add_argument('--verbose', '-v', action='store_true',
-                       help='Enable verbose logging')
-    
+    parser = argparse.ArgumentParser(
+        description="Shadow validation for hydroponic controller"
+    )
+    parser.add_argument(
+        "--data",
+        default="tests/data/sensors_sample.csv",
+        help="CSV file with sensor data (default: tests/data/sensors_sample.csv)",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose logging"
+    )
+
     args = parser.parse_args()
-    
-    setup_logging('DEBUG' if args.verbose else 'INFO')
+
+    setup_logging("DEBUG" if args.verbose else "INFO")
     logger = logging.getLogger(__name__)
-    
+
     validator = ShadowValidator(args.data)
-    
+
     try:
         logger.info("Starting shadow validation")
-        
+
         await validator.initialize()
         result = await validator.run_validation()
-        
+
         # Print results
         print(json.dumps(result, indent=2, default=str))
-        
-        if result.get('validation_passed', False):
+
+        if result.get("validation_passed", False):
             logger.info("Shadow validation PASSED")
             exit_code = 0
         else:
             logger.error("Shadow validation FAILED")
             exit_code = 1
-        
+
     except Exception as e:
         logger.error(f"Shadow validation script failed: {e}")
-        print(json.dumps({
-            "success": False,
-            "error": str(e),
-            "timestamp": datetime.utcnow().isoformat()
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "success": False,
+                    "error": str(e),
+                    "timestamp": datetime.utcnow().isoformat(),
+                },
+                indent=2,
+            )
+        )
         exit_code = 2
-    
+
     finally:
         await validator.cleanup()
-    
+
     sys.exit(exit_code)
 
 

--- a/scripts/shadow_validator.py
+++ b/scripts/shadow_validator.py
@@ -47,6 +47,7 @@ class ShadowValidator:
             "safety_violations": 0,
             "actions_taken": 0,
             "errors": [],
+            "warnings": [],
             "performance_metrics": {}
         }
     
@@ -240,7 +241,9 @@ class ShadowValidator:
             safety_violation = self._check_safety_violations(reading)
             if safety_violation:
                 self.results["safety_violations"] += 1
-                self.results["errors"].append(f"Safety violation at reading {index}: {safety_violation}")
+                self.results["warnings"].append(
+                    f"Safety violation at reading {index}: {safety_violation}"
+                )
             
             # Run control logic every 10 readings (simulating 10-minute intervals)
             if index % 10 == 0:

--- a/tests/test_shadow_day.py
+++ b/tests/test_shadow_day.py
@@ -2,9 +2,7 @@
 Tests for shadow day validation - replay sensor data and validate system behavior
 """
 
-import asyncio
 import csv
-import json
 import pytest
 import tempfile
 from datetime import datetime, timedelta
@@ -16,42 +14,54 @@ from scripts.shadow_validator import ShadowValidator
 
 class TestShadowDayValidation:
     """Test shadow day validation functionality"""
-    
+
     @pytest.fixture
     def sample_sensor_csv(self):
         """Create a sample sensor data CSV file"""
-        temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
-        
+        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+
         # Write CSV header
         fieldnames = [
-            "timestamp", "ph", "ec", "water_temp", "turbidity", "level_high", "level_low",
-            "air_temp", "humidity", "pressure", "co2", "root_temp", "lux", "led_power"
+            "timestamp",
+            "ph",
+            "ec",
+            "water_temp",
+            "turbidity",
+            "level_high",
+            "level_low",
+            "air_temp",
+            "humidity",
+            "pressure",
+            "co2",
+            "root_temp",
+            "lux",
+            "led_power",
         ]
-        
+
         writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
         writer.writeheader()
-        
+
         # Generate 24 hours of sample data (every 10 minutes = 144 readings)
         start_time = datetime.utcnow() - timedelta(days=1)
-        
+
         for i in range(144):
             timestamp = start_time + timedelta(minutes=i * 10)
-            
+
             # Simulate mostly good conditions with occasional issues
             ph_base = 6.0
             ec_base = 1.6
-            
+
             # Add some variation
             if i % 30 == 0:  # Every 5 hours, slight drift
                 ph_base += 0.1 if i % 60 == 0 else -0.1
                 ec_base += 0.05 if i % 60 == 0 else -0.05
-            
+
             # Occasional out-of-spec conditions (but not safety violations)
             if i == 50:  # One pH spike
                 ph_base = 6.8
             if i == 100:  # One EC dip
                 ec_base = 1.1
-            
+
             row = {
                 "timestamp": timestamp.isoformat(),
                 "ph": round(max(5.0, min(7.0, ph_base)), 2),
@@ -66,38 +76,50 @@ class TestShadowDayValidation:
                 "co2": 800,
                 "root_temp": 21.0,
                 "lux": 25000,
-                "led_power": 80 if 6 <= timestamp.hour <= 22 else 0
+                "led_power": 80 if 6 <= timestamp.hour <= 22 else 0,
             }
-            
+
             writer.writerow(row)
-        
+
         temp_file.close()
         return temp_file.name
-    
+
     @pytest.fixture
     def problematic_sensor_csv(self):
         """Create sensor data with safety violations"""
-        temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
-        
+        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+
         fieldnames = [
-            "timestamp", "ph", "ec", "water_temp", "turbidity", "level_high", "level_low",
-            "air_temp", "humidity", "pressure", "co2", "root_temp", "lux", "led_power"
+            "timestamp",
+            "ph",
+            "ec",
+            "water_temp",
+            "turbidity",
+            "level_high",
+            "level_low",
+            "air_temp",
+            "humidity",
+            "pressure",
+            "co2",
+            "root_temp",
+            "lux",
+            "led_power",
         ]
-        
+
         writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
         writer.writeheader()
-        
+
         # Generate data with safety violations
         start_time = datetime.utcnow() - timedelta(hours=2)
-        
+
         for i in range(12):  # 2 hours of data, every 10 minutes
             timestamp = start_time + timedelta(minutes=i * 10)
-            
+
             # Include safety violations
             ph_value = 3.5 if i == 5 else 6.0  # One critical pH violation
             ec_value = 4.0 if i == 8 else 1.6  # One critical EC violation
             level_high = "false" if i == 10 else "true"  # One water level issue
-            
+
             row = {
                 "timestamp": timestamp.isoformat(),
                 "ph": ph_value,
@@ -112,259 +134,294 @@ class TestShadowDayValidation:
                 "co2": 800,
                 "root_temp": 21.0,
                 "lux": 25000,
-                "led_power": 80
+                "led_power": 80,
             }
-            
+
             writer.writerow(row)
-        
+
         temp_file.close()
         return temp_file.name
-    
+
     @pytest.mark.asyncio
     @pytest.mark.integration
     async def test_shadow_validation_good_data(self, sample_sensor_csv):
         """Test shadow validation with good sensor data"""
         validator = ShadowValidator(sample_sensor_csv)
-        
+
         try:
             await validator.initialize()
             result = await validator.run_validation()
-            
-            assert result['success'] == True
-            assert result['total_readings'] == 144
-            
+
+            assert result["success"]
+            assert result["total_readings"] == 144
+
             # Should meet requirements with good data
-            performance = result['performance_metrics']
-            assert performance['in_spec_percentage'] >= 95.0
-            assert result['safety_violations'] == 0
-            assert performance['error_rate'] < 1.0
-            
+            performance = result["performance_metrics"]
+            assert performance["in_spec_percentage"] >= 95.0
+            assert result["safety_violations"] == 0
+            assert performance["error_rate"] < 1.0
+
             # Validation should pass
-            assert result['validation_passed'] == True
-            
-            requirements = result['requirements_check']
-            assert requirements['in_spec_requirement']['passed'] == True
-            assert requirements['safety_requirement']['passed'] == True
-            assert requirements['error_requirement']['passed'] == True
-            
+            assert result["validation_passed"]
+
+            requirements = result["requirements_check"]
+            assert requirements["in_spec_requirement"]["passed"]
+            assert requirements["safety_requirement"]["passed"]
+            assert requirements["error_requirement"]["passed"]
+
         finally:
             await validator.cleanup()
             # Cleanup temp file
             try:
                 Path(sample_sensor_csv).unlink()
-            except:
+            except Exception:
                 pass
-    
+
     @pytest.mark.asyncio
     async def test_shadow_validation_problematic_data(self, problematic_sensor_csv):
         """Test shadow validation with problematic sensor data"""
         validator = ShadowValidator(problematic_sensor_csv)
 
         try:
-            with patch('scripts.shadow_validator.LLMAgent'):
+            with patch("scripts.shadow_validator.LLMAgent"):
                 await validator.initialize()
                 validator.db.get_database_stats = AsyncMock(return_value={})
                 result = await validator.run_validation()
 
-            assert result['success'] is True  # Script ran successfully
-            assert result['total_readings'] == 12
+            assert result["success"] is True  # Script ran successfully
+            assert result["total_readings"] == 12
 
             # Should detect safety violations without failing overall execution
-            assert result['safety_violations'] > 0
+            assert result["safety_violations"] > 0
             assert len(result["warnings"]) >= result["safety_violations"]
 
             # Validation should fail due to safety violations
-            assert result['validation_passed'] is False
+            assert result["validation_passed"] is False
 
-            requirements = result['requirements_check']
-            assert requirements['safety_requirement']['passed'] is False
+            requirements = result["requirements_check"]
+            assert requirements["safety_requirement"]["passed"] is False
 
         finally:
             await validator.cleanup()
             # Cleanup temp file
             try:
                 Path(problematic_sensor_csv).unlink()
-            except:
+            except Exception:
                 pass
-    
+
     @pytest.mark.asyncio
     async def test_sensor_data_loading(self, sample_sensor_csv):
         """Test sensor data loading from CSV"""
         validator = ShadowValidator(sample_sensor_csv)
-        
+
         try:
             await validator.initialize()
-            
+
             # Load sensor data
             readings = validator._load_sensor_data()
-            
+
             assert len(readings) == 144
-            
+
             # Check data structure
             for reading in readings[:5]:  # Check first 5 readings
-                assert 'timestamp' in reading
-                assert 'water' in reading
-                assert 'air' in reading
-                assert 'root' in reading
-                assert 'light' in reading
-                
+                assert "timestamp" in reading
+                assert "water" in reading
+                assert "air" in reading
+                assert "root" in reading
+                assert "light" in reading
+
                 # Check data types
-                assert isinstance(reading['water']['ph'], float)
-                assert isinstance(reading['water']['ec'], float)
-                assert isinstance(reading['air']['temperature'], float)
-                assert isinstance(reading['air']['co2'], int)
-                assert isinstance(reading['water']['level_high'], bool)
-            
+                assert isinstance(reading["water"]["ph"], float)
+                assert isinstance(reading["water"]["ec"], float)
+                assert isinstance(reading["air"]["temperature"], float)
+                assert isinstance(reading["air"]["co2"], int)
+                assert isinstance(reading["water"]["level_high"], bool)
+
         finally:
             await validator.cleanup()
             # Cleanup temp file
             try:
                 Path(sample_sensor_csv).unlink()
-            except:
+            except Exception:
                 pass
-    
+
     @pytest.mark.asyncio
     async def test_reading_validation(self, sample_sensor_csv):
         """Test individual reading validation"""
         validator = ShadowValidator(sample_sensor_csv)
-        
+
         try:
             await validator.initialize()
-            
+
             # Test valid reading
             valid_reading = {
-                'water': {'ph': 6.0, 'ec': 1.6, 'temperature': 22.0, 'level_high': True, 'level_low': True},
-                'air': {'temperature': 24.0, 'humidity': 60.0, 'co2': 800}
+                "water": {
+                    "ph": 6.0,
+                    "ec": 1.6,
+                    "temperature": 22.0,
+                    "level_high": True,
+                    "level_low": True,
+                },
+                "air": {"temperature": 24.0, "humidity": 60.0, "co2": 800},
             }
-            
-            assert validator._check_reading_in_spec(valid_reading) == True
+
+            assert validator._check_reading_in_spec(valid_reading)
             assert validator._check_safety_violations(valid_reading) is None
-            
+
             # Test invalid reading
             invalid_reading = {
-                'water': {'ph': 3.0, 'ec': 4.0, 'temperature': 22.0, 'level_high': False, 'level_low': False},
-                'air': {'temperature': 45.0, 'humidity': 60.0, 'co2': 800}
+                "water": {
+                    "ph": 3.0,
+                    "ec": 4.0,
+                    "temperature": 22.0,
+                    "level_high": False,
+                    "level_low": False,
+                },
+                "air": {"temperature": 45.0, "humidity": 60.0, "co2": 800},
             }
-            
-            assert validator._check_reading_in_spec(invalid_reading) == False
+
+            assert not validator._check_reading_in_spec(invalid_reading)
             safety_violation = validator._check_safety_violations(invalid_reading)
             assert safety_violation is not None
-            assert 'pH' in safety_violation or 'EC' in safety_violation or 'water level' in safety_violation
-            
+            assert (
+                "pH" in safety_violation
+                or "EC" in safety_violation
+                or "water level" in safety_violation
+            )
+
         finally:
             await validator.cleanup()
-    
+
     @pytest.mark.asyncio
     async def test_control_logic_execution(self, sample_sensor_csv):
         """Test control logic execution during shadow validation"""
         validator = ShadowValidator(sample_sensor_csv)
-        
+
         try:
             await validator.initialize()
-            
+
             # Mock reading that should trigger actions
             problematic_reading = {
-                'timestamp': datetime.utcnow().isoformat(),
-                'water': {'ph': 6.8, 'ec': 1.2, 'temperature': 22.0, 'level_high': True, 'level_low': True},
-                'air': {'temperature': 28.0, 'humidity': 60.0, 'co2': 800},
-                'root': {'temperature': 21.0},
-                'light': {'lux': 25000, 'led_power': 80}
+                "timestamp": datetime.utcnow().isoformat(),
+                "water": {
+                    "ph": 6.8,
+                    "ec": 1.2,
+                    "temperature": 22.0,
+                    "level_high": True,
+                    "level_low": True,
+                },
+                "air": {"temperature": 28.0, "humidity": 60.0, "co2": 800},
+                "root": {"temperature": 21.0},
+                "light": {"lux": 25000, "led_power": 80},
             }
-            
+
             # Process reading (should trigger control logic)
-            await validator._process_reading(problematic_reading, 10)  # Every 10th reading
-            
+            await validator._process_reading(
+                problematic_reading, 10
+            )  # Every 10th reading
+
             # Check that actions were recorded
-            assert validator.results['actions_taken'] >= 0  # Should be incremented if actions taken
-            
+            assert (
+                validator.results["actions_taken"] >= 0
+            )  # Should be incremented if actions taken
+
         finally:
             await validator.cleanup()
-    
+
     def test_requirements_validation(self):
         """Test requirements validation logic"""
         validator = ShadowValidator()
-        
+
         # Test passing requirements
         validator.results = {
-            'total_readings': 100,
-            'in_spec_readings': 96,
-            'safety_violations': 0,
-            'errors': [],
-            'performance_metrics': {
-                'in_spec_percentage': 96.0,
-                'error_rate': 0.0
-            }
+            "total_readings": 100,
+            "in_spec_readings": 96,
+            "safety_violations": 0,
+            "errors": [],
+            "performance_metrics": {"in_spec_percentage": 96.0, "error_rate": 0.0},
         }
-        
-        assert validator._validate_requirements() == True
-        
+
+        assert validator._validate_requirements()
+
         # Test failing requirements (low in-spec percentage)
-        validator.results['performance_metrics']['in_spec_percentage'] = 90.0
-        assert validator._validate_requirements() == False
-        
+        validator.results["performance_metrics"]["in_spec_percentage"] = 90.0
+        assert not validator._validate_requirements()
+
         # Test failing requirements (safety violations)
-        validator.results['performance_metrics']['in_spec_percentage'] = 96.0
-        validator.results['safety_violations'] = 1
-        assert validator._validate_requirements() == False
-    
+        validator.results["performance_metrics"]["in_spec_percentage"] = 96.0
+        validator.results["safety_violations"] = 1
+        assert not validator._validate_requirements()
+
     @pytest.mark.asyncio
     async def test_create_sample_data(self):
         """Test sample data creation when no CSV file exists"""
         # Use non-existent file path
         non_existent_file = "/tmp/test_sensors_nonexistent.csv"
-        
+
         validator = ShadowValidator(non_existent_file)
-        
+
         try:
             await validator.initialize()
-            
+
             # Should create sample data
             readings = validator._load_sensor_data()
-            
+
             assert len(readings) > 0
             assert len(readings) == 1440  # 24 hours * 60 minutes
-            
+
             # Verify created file exists
             assert Path(non_existent_file).exists()
-            
+
             # Check data quality
-            ph_values = [r['water']['ph'] for r in readings]
+            ph_values = [r["water"]["ph"] for r in readings]
             assert min(ph_values) >= 4.0
             assert max(ph_values) <= 8.0
-            
+
         finally:
             await validator.cleanup()
             # Cleanup created file
             try:
                 Path(non_existent_file).unlink()
-            except:
+            except Exception:
                 pass
 
 
 class TestShadowValidationPerformance:
     """Test shadow validation performance and edge cases"""
-    
+
     @pytest.mark.asyncio
     @pytest.mark.slow
     async def test_large_dataset_validation(self):
         """Test validation with large dataset (week's worth of data)"""
         # Create large temporary dataset
-        temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
-        
+        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+
         fieldnames = [
-            "timestamp", "ph", "ec", "water_temp", "turbidity", "level_high", "level_low",
-            "air_temp", "humidity", "pressure", "co2", "root_temp", "lux", "led_power"
+            "timestamp",
+            "ph",
+            "ec",
+            "water_temp",
+            "turbidity",
+            "level_high",
+            "level_low",
+            "air_temp",
+            "humidity",
+            "pressure",
+            "co2",
+            "root_temp",
+            "lux",
+            "led_power",
         ]
-        
+
         writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
         writer.writeheader()
-        
+
         # Generate week's worth of data (7 days * 24 hours * 6 readings/hour = 1008 readings)
         start_time = datetime.utcnow() - timedelta(days=7)
-        
+
         for i in range(1008):
             timestamp = start_time + timedelta(minutes=i * 10)
-            
+
             row = {
                 "timestamp": timestamp.isoformat(),
                 "ph": 6.0,
@@ -379,52 +436,54 @@ class TestShadowValidationPerformance:
                 "co2": 800,
                 "root_temp": 21.0,
                 "lux": 25000,
-                "led_power": 80
+                "led_power": 80,
             }
-            
+
             writer.writerow(row)
-        
+
         temp_file.close()
-        
+
         validator = ShadowValidator(temp_file.name)
-        
+
         try:
             await validator.initialize()
             result = await validator.run_validation()
-            
-            assert result['success'] == True
-            assert result['total_readings'] == 1008
-            
+
+            assert result["success"]
+            assert result["total_readings"] == 1008
+
             # Should still meet performance requirements
-            assert result['validation_passed'] == True
-            
+            assert result["validation_passed"]
+
         finally:
             await validator.cleanup()
             try:
                 Path(temp_file.name).unlink()
-            except:
+            except Exception:
                 pass
-    
+
     @pytest.mark.asyncio
     async def test_validation_error_handling(self):
         """Test shadow validation error handling"""
         # Test with invalid CSV file
-        temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
-        temp_file.write("invalid,csv,data\n1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17")  # Wrong number of columns
+        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        temp_file.write(
+            "invalid,csv,data\n1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17"
+        )  # Wrong number of columns
         temp_file.close()
-        
+
         validator = ShadowValidator(temp_file.name)
-        
+
         try:
             await validator.initialize()
             result = await validator.run_validation()
-            
+
             # Should handle errors gracefully
-            assert 'error' in result or len(result.get('errors', [])) > 0
-            
+            assert "error" in result or len(result.get("errors", [])) > 0
+
         finally:
             await validator.cleanup()
             try:
                 Path(temp_file.name).unlink()
-            except:
+            except Exception:
                 pass


### PR DESCRIPTION
## Summary
- mark safety issues as warnings instead of errors in `ShadowValidator`
- mock `LLMAgent` and DB stats in problematic data test
- assert warnings and success when violations occur

## Testing
- `pytest tests/test_shadow_day.py::TestShadowDayValidation::test_shadow_validation_problematic_data -vv`
- `pytest tests/test_shadow_day.py::TestShadowDayValidation::test_shadow_validation_good_data -vv`
- `pytest -k "not slow" -q`

------
https://chatgpt.com/codex/tasks/task_e_6889914e3b188329b63de2429b016ca6